### PR TITLE
Add checkboxProps prop and fix id type

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,13 @@ should work of the example project.
 | -------- | :---------------: | :-------: | --------------------------------------------------------- |
 | data     | ICheckboxButton[] | undefined | set the checkboxes as a data                              |
 | onChange |     function      | undefined | set your own logic when the group of checkbox is selected |
+| checkboxProps | IBouncyCheckboxProps | undefined | default props for all checkboxes |
 
 ## Customization (Optionals)
 
 #### [React Native Bouncy Checkbox Customizations](https://github.com/WrathChaos/react-native-bouncy-checkbox#configuration---props)
 
-You can use all of the customiztion options from the rn bouncy checkbox. You NEED to add the styling and props into the `data`. Therefore, you can customize each of the checkboxes easly.
+You can use all of the customiztion options from the rn bouncy checkbox. You NEED to add the styling and props into the `data`. Therefore, you can customize each of the checkboxes easily.
 
 ## Future Plans
 

--- a/lib/BouncyCheckboxGroup.tsx
+++ b/lib/BouncyCheckboxGroup.tsx
@@ -12,7 +12,7 @@ import useStateWithCallback from "./helpers/useStateWithCallback";
 type CustomStyleProp = StyleProp<ViewStyle> | Array<StyleProp<ViewStyle>>;
 
 export interface ICheckboxButton extends IBouncyCheckboxProps {
-  id: number;
+  id: string | number;
 }
 
 interface IBouncyCheckboxGroupProps {
@@ -20,10 +20,12 @@ interface IBouncyCheckboxGroupProps {
   initial?: number;
   data: ICheckboxButton[];
   onChange: (selectedItem: ICheckboxButton) => void;
+  checkboxProps?: IBouncyCheckboxProps;
 }
 
 const BouncyCheckboxGroup: React.FC<IBouncyCheckboxGroupProps> = ({
   style,
+  checkboxProps,
   initial,
   data,
   onChange,
@@ -44,6 +46,7 @@ const BouncyCheckboxGroup: React.FC<IBouncyCheckboxGroupProps> = ({
             item.id === (selectedItem ? selectedItem?.id : initial);
           return (
             <BouncyCheckbox
+              {...checkboxProps}
               {...item}
               key={item.id}
               disableBuiltInState


### PR DESCRIPTION
Fixes the id type #2

Allows defining the style prop inside the checkboxProps, and also any other prop of the main lib. #3. Besides the margin that I added for my case, I also added in my code the strikethrough remove (that in my opinion shouldn't be the default at all)